### PR TITLE
feat: Add separate moderation log channel

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,5 +9,9 @@
     "count": 3,
     "refreshPeriod": 3600
   },
+  "modLog": {
+    "category": "pleasantcord",
+    "channel": "moderation-log"
+  },
   "ban": false
 }

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -2,20 +2,24 @@ import { Guild } from 'discord.js';
 
 import { Logger, LogLevel } from '../../service/logger';
 import { BotContext } from '../types';
-import { syncModerationChannels } from '../utils';
+import { handleError, syncModerationChannels } from '../utils';
 
 export default {
   event: 'guildCreate',
   fn: async ({ config }: BotContext, guild: Guild): Promise<void> => {
-    await syncModerationChannels(
-      guild,
-      config,
-    );
+    try {
+      await syncModerationChannels(
+        guild,
+        config,
+      );
 
-    Logger.getInstance().logBot(
-      // eslint-disable-next-line max-len
-      `Successfully initialized ${config.name}'s moderation channel on ${guild.name} (#${guild.id})`,
-      LogLevel.INFO,
-    );
+      Logger.getInstance().logBot(
+        // eslint-disable-next-line max-len
+        `Successfully initialized ${config.name}'s moderation channel on ${guild.name} (#${guild.id})`,
+        LogLevel.INFO,
+      );
+    } catch (err) {
+      handleError(config, err);
+    }
   },
 };

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -1,0 +1,21 @@
+import { Guild } from 'discord.js';
+
+import { Logger, LogLevel } from '../../service/logger';
+import { BotContext } from '../types';
+import { syncModerationChannels } from '../utils';
+
+export default {
+  event: 'guildCreate',
+  fn: async ({ config }: BotContext, guild: Guild): Promise<void> => {
+    await syncModerationChannels(
+      guild,
+      config,
+    );
+
+    Logger.getInstance().logBot(
+      // eslint-disable-next-line max-len
+      `Successfully initialized ${config.name}'s moderation channel on ${guild.name} (#${guild.id})`,
+      LogLevel.INFO,
+    );
+  },
+};

--- a/src/bot/events/guildDelete.ts
+++ b/src/bot/events/guildDelete.ts
@@ -1,68 +1,60 @@
 import { Guild } from 'discord.js';
-import { Logger, LogLevel } from '../../service/logger';
 
 import { BotContext } from '../types';
+import { handleError } from '../utils';
 
 export default {
   name: 'guildDelete',
   fn: async ({ config }: BotContext, guild: Guild): Promise<void> => {
-    const { modLog } = config;
-    const { category, channel: modName } = modLog;
+    try {
+      const { modLog } = config;
+      const { category, channel: modName } = modLog;
 
-    const categoryChannel = guild.channels.cache.find(
-      channel => channel.type === 'category' && channel.name === category,
-    );
-
-    if (!categoryChannel) {
-      Logger.getInstance().logBot(
-        // eslint-disable-next-line max-len
-        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Category channel does not exist`,
-        LogLevel.ERROR,
+      const categoryChannel = guild.channels.cache.find(
+        channel => channel.type === 'category' && channel.name === category,
       );
 
-      return;
+      if (!categoryChannel) {
+        throw new Error(
+          // eslint-disable-next-line max-len
+          `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Category channel does not exist`,
+        );
+      }
+
+      if (!categoryChannel.deletable || !categoryChannel.deleted) {
+        throw new Error(
+          // eslint-disable-next-line max-len
+          `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Category channel is not deletable`,
+        );
+      }
+
+      const textChannel = guild.channels.cache.find((channel) => {
+        return channel.type === 'text' &&
+          channel.name === modName &&
+          channel.parent !== null &&
+          channel.parent === categoryChannel;
+      });
+
+      if (!textChannel) {
+        throw new Error(
+          // eslint-disable-next-line max-len
+          `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Text channel does not exist`,
+        );
+      }
+
+      if (!textChannel.deletable || !textChannel.deleted) {
+        throw new Error(
+          // eslint-disable-next-line max-len
+          `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Text channel is not deletable`,
+        );
+      }
+
+      await Promise.all([
+        categoryChannel.delete(`${config.name} cleanup hook`),
+        textChannel.delete(`${config.name} cleanup hook`),
+      ]);
+    } catch (err) {
+      handleError(config, err);
     }
-
-    if (!categoryChannel.deletable || !categoryChannel.deleted) {
-      Logger.getInstance().logBot(
-        // eslint-disable-next-line max-len
-        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Category channel is not deletable`,
-        LogLevel.ERROR,
-      );
-
-      return;
-    }
-
-    const textChannel = guild.channels.cache.find((channel) => {
-      return channel.type === 'text' &&
-        channel.name === modName &&
-        channel.parent !== null &&
-        channel.parent === categoryChannel;
-    });
-
-    if (!textChannel) {
-      Logger.getInstance().logBot(
-        // eslint-disable-next-line max-len
-        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Text channel does not exist`,
-        LogLevel.ERROR,
-      );
-
-      return;
-    }
-
-    if (!textChannel.deletable || !textChannel.deleted) {
-      Logger.getInstance().logBot(
-        // eslint-disable-next-line max-len
-        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Text channel is not deletable`,
-        LogLevel.ERROR,
-      );
-
-      return;
-    }
-
-    await Promise.all([
-      categoryChannel.delete(`${config.name} cleanup hook`),
-      textChannel.delete(`${config.name} cleanup hook`),
-    ]);
   },
 };

--- a/src/bot/events/guildDelete.ts
+++ b/src/bot/events/guildDelete.ts
@@ -1,0 +1,68 @@
+import { Guild } from 'discord.js';
+import { Logger, LogLevel } from '../../service/logger';
+
+import { BotContext } from '../types';
+
+export default {
+  name: 'guildDelete',
+  fn: async ({ config }: BotContext, guild: Guild): Promise<void> => {
+    const { modLog } = config;
+    const { category, channel: modName } = modLog;
+
+    const categoryChannel = guild.channels.cache.find(
+      channel => channel.type === 'category' && channel.name === category,
+    );
+
+    if (!categoryChannel) {
+      Logger.getInstance().logBot(
+        // eslint-disable-next-line max-len
+        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Category channel does not exist`,
+        LogLevel.ERROR,
+      );
+
+      return;
+    }
+
+    if (!categoryChannel.deletable || !categoryChannel.deleted) {
+      Logger.getInstance().logBot(
+        // eslint-disable-next-line max-len
+        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Category channel is not deletable`,
+        LogLevel.ERROR,
+      );
+
+      return;
+    }
+
+    const textChannel = guild.channels.cache.find((channel) => {
+      return channel.type === 'text' &&
+        channel.name === modName &&
+        channel.parent !== null &&
+        channel.parent === categoryChannel;
+    });
+
+    if (!textChannel) {
+      Logger.getInstance().logBot(
+        // eslint-disable-next-line max-len
+        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Text channel does not exist`,
+        LogLevel.ERROR,
+      );
+
+      return;
+    }
+
+    if (!textChannel.deletable || !textChannel.deleted) {
+      Logger.getInstance().logBot(
+        // eslint-disable-next-line max-len
+        `${config.name} on ${guild.name} (#${guild.id}) is misconfigured: Text channel is not deletable`,
+        LogLevel.ERROR,
+      );
+
+      return;
+    }
+
+    await Promise.all([
+      categoryChannel.delete(`${config.name} cleanup hook`),
+      textChannel.delete(`${config.name} cleanup hook`),
+    ]);
+  },
+};

--- a/src/bot/events/ready.ts
+++ b/src/bot/events/ready.ts
@@ -1,4 +1,95 @@
-import { BotContext } from '../types';
+import {
+  Collection,
+  Guild,
+  GuildMember,
+  OverwriteResolvable,
+} from 'discord.js';
+
+import { BotConfig, BotContext } from '../types';
+
+async function syncModerationChannels(
+  guilds: Collection<string, Guild>,
+  { modLog }: BotConfig,
+): Promise<void> {
+  // setup channel for bot log
+  const resolveChannels = guilds.map(async (guild) => {
+    let categoryChannel = guild.channels.cache.find(
+      channel => channel.name === modLog.category &&
+        channel.type === 'category',
+    );
+
+    let textChannel = guild.channels.cache.find(
+      channel => channel.name === modLog.channel &&
+        channel.type === 'text',
+    );
+
+    const permissions: OverwriteResolvable[] = guild.roles.cache.map(
+      (role) => {
+        return {
+          id: role.id,
+          allow: [
+            'VIEW_CHANNEL',
+            'READ_MESSAGE_HISTORY',
+          ],
+          deny: [
+            'SEND_MESSAGES',
+            'ADD_REACTIONS',
+            'MANAGE_MESSAGES',
+          ],
+        };
+      },
+    );
+
+    if (!categoryChannel) {
+      categoryChannel = await guild.channels.create(
+        modLog.category,
+        {
+          type: 'category',
+          permissionOverwrites: permissions,
+        },
+      );
+    } else {
+      categoryChannel.overwritePermissions([
+        ...permissions,
+      ]);
+    }
+
+    await categoryChannel.overwritePermissions([
+      {
+        id: guild.me as GuildMember,
+        allow: [
+          'SEND_MESSAGES',
+        ],
+      },
+    ]);
+
+    if (!textChannel) {
+      textChannel = await guild.channels.create(
+        modLog.channel,
+        {
+          type: 'text',
+          parent: categoryChannel,
+          permissionOverwrites: permissions,
+        },
+      );
+    } else {
+      await textChannel.overwritePermissions([
+        ...permissions,
+      ]);
+    }
+
+    await textChannel.overwritePermissions([
+      {
+        id: guild.me as GuildMember,
+        allow: [
+          'SEND_MESSAGES',
+        ],
+      },
+    ]);
+  });
+
+  await Promise.all(resolveChannels);
+}
 
 export default {
   event: 'ready',
@@ -8,12 +99,19 @@ export default {
       console.log(`${config.name} is now ready to moderate servers`);
     }
 
-    await client.user?.setPresence({
+    const setPresence = client.user?.setPresence({
       status: 'online',
       activity: {
         name: 'for NSFW contents ⚖️',
         type: 'WATCHING',
       },
     });
+
+    const syncChannels = syncModerationChannels(
+      client.guilds.cache,
+      config,
+    );
+
+    await Promise.all([setPresence, syncChannels]);
   },
 };

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -12,6 +12,10 @@ export interface BotConfig {
     count: number;
     refreshPeriod: number;
   };
+  modLog: {
+    category: string;
+    channel: string;
+  };
   ban: boolean;
 }
 

--- a/src/service/logger.ts
+++ b/src/service/logger.ts
@@ -39,9 +39,7 @@ export class Logger {
     this.logger.info(`[cron] ${msg}`);
   }
 
-  public logBot(msg: string, level: LogLevel = LogLevel.ERROR): void {
-    msg = `[bot]: ${msg}`;
-
+  private multiLevelLog(msg: string, level: LogLevel): void {
     switch (level) {
       case LogLevel.INFO: {
         this.logger.info(msg);
@@ -56,5 +54,17 @@ export class Logger {
         break;
       }
     }
+  }
+
+  public logBot(msg: string, level: LogLevel = LogLevel.ERROR): void {
+    msg = `[bot]: ${msg}`;
+
+    this.multiLevelLog(msg, level);
+  }
+
+  public logDb(msg: string, level: LogLevel = LogLevel.ERROR): void {
+    msg = `[db]: ${msg}`;
+
+    this.multiLevelLog(msg, level);
   }
 }


### PR DESCRIPTION
## Overview

This pull request adds a separate moderation log channel for any moderation logs. Logs such as ban, kicks, and error logging are sent to the new channel instead. However, content censorship messages are still sent to their respective channel.