### PR TITLE
fix(ci): Add missing 's' to 'permissions'

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
-    permission:
+    permissions:
       contents: read
       packages: write
 


### PR DESCRIPTION
## Overview

This pull request adds missing `s` to the word `permissions` on `publish-image.yml` which causes the action to fail due to invalid syntax.