### PR TITLE
fix(docs): change support server link to actual server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ I'm not the one who created the model, so I can't say anything about it. That be
 
 Technically, `pleasantcord` won't store any of your data. However when `pleasantcord` has encountered an error on your server, `pleasantcord` will store the stacktrace on the logging system which *may* include your personal data (which is 100% embeddable content). This is done to ensure easier error debugging and fixing.
 
-When the issue has been detected, acknowledged, and analyzed, your personal data will **immediately** deleted. If you feel that your data is still stored on our system, feel free to [join our support server](https://discord.com/api/oauth2/authorize?client_id=750668307555942482&permissions=10240&scope=bot) and contact the moderators directly.
+When the issue has been detected, acknowledged, and analyzed, your personal data will **immediately** deleted. If you feel that your data is still stored on our system, feel free to [join our support server](https://discord.gg/Pj4aGp8Aky) and contact the moderators directly.
 
 ## Credits
 


### PR DESCRIPTION
## Overview

This pull request fixes the support server link in the README file with the correct one.

> This won't trigger any releases.