### PR TITLE
refactor: revert back to old API format

### DIFF
--- a/src/bot/commands/config.ts
+++ b/src/bot/commands/config.ts
@@ -4,7 +4,7 @@ import { BotContext } from '../types';
 
 export default {
   command: 'config',
-  description: 'Show pleasantcord\'s configuration for the current guild',
+  description: 'Show configuration for the current server',
   fn: async (
     { configRepository }: BotContext,
     msg: Message,

--- a/src/bot/commands/status.ts
+++ b/src/bot/commands/status.ts
@@ -8,7 +8,7 @@ const packageInfo = require(resolve(process.cwd(), 'package.json'));
 export default {
   command: 'status',
   description: 'Show the bot status',
-  fn: async (_: BotContext, msg: Message): Promise<Message> => {
+  fn: async ({ client }: BotContext, msg: Message): Promise<Message> => {
     const time = Date.now() - msg.createdTimestamp;
 
     let packageVersion: string = packageInfo.dependencies['discord.js'];
@@ -23,6 +23,11 @@ export default {
         name: 'Bot Environment',
         // eslint-disable-next-line max-len
         value: `**NodeJS Version**: ${process.version.slice(1)}\n**Framework**: DiscordJS ${packageVersion}`,
+      },
+      {
+        name: 'Active Servers',
+        value: `${client.guilds.cache.size} servers`,
+        inline: true,
       },
       {
         name: 'Response Time',

--- a/src/repository/config.ts
+++ b/src/repository/config.ts
@@ -5,7 +5,6 @@ import { Configuration } from '../entity/config';
 import { Logger } from '../utils/logger';
 
 import type { HeadersInit } from 'node-fetch';
-import { Label } from '../entity/content';
 
 export interface ConfigurationRepository {
   setBotId: (id: string) => void;
@@ -104,8 +103,7 @@ implements ConfigurationRepository {
       );
 
       const json = await result.json();
-
-      return this.convertConfigToRawConfig(json.data);
+      return json['data'];
     } catch (err) {
       Logger.getInstance().logBot(
         new Error('Failed to fetch configuration from API'),
@@ -149,16 +147,5 @@ implements ConfigurationRepository {
         new Error('Failed to delete configuration'),
       );
     }
-  }
-
-  private convertConfigToRawConfig(
-    config: Record<string, unknown>,
-  ): Configuration {
-    return {
-      accuracy: config['accuracy'] as number,
-      categories: (config['categories'] as Record<string, unknown>[])
-        .map(val => val.name as Label),
-      delete: config['delete'] as boolean,
-    };
   }
 }


### PR DESCRIPTION
## Overview

This pull request reverts the configuration repository formatting to old format, as description is not needed in bot context.