### PR TITLE
chore: use single instance for process management

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,7 +5,7 @@ module.exports = {
       script: './dist/index.js',
       restart_delay: 1000,
       stop_exit_codes: [0],
-      instances: -1,
+      instances: 1,
       exec_mode: 'cluster',
       env: {
         NODE_ENV: 'production',


### PR DESCRIPTION
## Overview

This pull request fixes the pm2 configuration by setting it to run a single instance to prevent multiple responses from the bot as Discord JS does not support clustering.