### PR TITLE
feat: add dashboard link to common commands

### DIFF
--- a/src/bot/commands/config.ts
+++ b/src/bot/commands/config.ts
@@ -35,6 +35,10 @@ export default {
           name: 'Delete NSFW Contents',
           value: config.delete ? 'Yes' : 'No',
         },
+        {
+          name: 'Dashboard Link',
+          value: '[https://pleasantcord.namchee.dev](https://pleasantcord.namchee.dev)',
+        },
       ],
       color: process.env.NODE_ENV === 'development' ?
         '#2674C2' :

--- a/src/bot/commands/help.ts
+++ b/src/bot/commands/help.ts
@@ -31,8 +31,12 @@ export default {
           value: commands.join('\n'),
         },
         {
+          name: 'Configuration',
+          value: `You can configure \`pleasantcord\`'s behavior on your server from [our dashboard](https://pleasantcord.namchee.dev)`,
+        },
+        {
           name: 'Contribution',
-          value: `Contribute to \`pleasantcord\`'s development on [GitHub](https://github.com/Namchee/pleasantcord)`,
+          value: `You can contribute to \`pleasantcord\`'s development on [GitHub](https://github.com/Namchee/pleasantcord)`,
         },
       ],
       color: process.env.NODE_ENV === 'development' ?


### PR DESCRIPTION
## Overview

This pull request adds the dashboard link to common bot commands, such as `help` and `config`