### PR TITLE
fix: remove Awaited types

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -20,3 +20,5 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Lint code
         run: yarn lint
+      - name: Build the code
+        run: yarn build

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -1,4 +1,4 @@
-import { Awaited, Client, ClientEvents, Message } from 'discord.js';
+import { Client, ClientEvents, Message } from 'discord.js';
 
 import { ConfigurationService } from '../service/config';
 import { RateLimiter } from '../service/rate-limit';
@@ -15,7 +15,7 @@ export interface BotContext {
 export interface EventHandler {
   event: keyof ClientEvents;
   once?: boolean;
-  fn: (ctx: BotContext) => Awaited<void>;
+  fn: (ctx: BotContext) => Promise<void>;
 }
 
 /**
@@ -26,7 +26,7 @@ export interface EventHandler {
 export type CommandHandlerFunction = (
   ctx: BotContext,
   msg: Message,
-) => Awaited<void>;
+) => Promise<void>;
 
 /**
  * Command handler.


### PR DESCRIPTION
## Overview

This pull request removes `Awaited` references from `bot/types.ts` as DiscordJS is not dependent on that type anymore.