### PR TITLE
chore(deps): bump node-fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "discord.js": "^13.1.0",
     "dotenv": "^10.0.0",
     "node-cache": "^5.1.2",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^3.2.0",
     "nsfwjs": "^2.4.1",
     "pm2": "^5.1.2",
     "sharp": "^0.29.0",

--- a/src/entity/api.ts
+++ b/src/entity/api.ts
@@ -1,0 +1,5 @@
+// APIResponse represents response from pleasantcord's API server
+export interface APIResponse<T> {
+  data: T;
+  error: string;
+}

--- a/src/entity/config.ts
+++ b/src/entity/config.ts
@@ -1,6 +1,5 @@
 import { Label } from '../entity/content';
 
-
 // pleasantcord's server configuration. Unique per server.
 export interface Configuration {
   // Minimum accuracy level to be classified as NSFW

--- a/src/repository/config.ts
+++ b/src/repository/config.ts
@@ -54,7 +54,6 @@ implements ConfigurationRepository {
     };
   }
 
-
   public setBotId(id: string): void {
     this.userId = id;
   }
@@ -79,7 +78,7 @@ implements ConfigurationRepository {
     }
 
     const json = await result.json();
-    return json['data'];
+    return json['data'] as Configuration | null;
   }
 
   public async createConfig(

--- a/src/repository/config.ts
+++ b/src/repository/config.ts
@@ -6,6 +6,7 @@ import { Logger } from '../utils/logger';
 import type { HeadersInit } from 'node-fetch';
 import NodeCache from 'node-cache';
 import { FIVE_MINUTES } from '../constants/time';
+import { APIResponse } from '../entity/api';
 
 export interface ConfigurationCache {
   getConfig: (id: string) => Configuration | null;
@@ -67,18 +68,19 @@ implements ConfigurationRepository {
       },
     );
 
+    const json = (await result.json()) as APIResponse<Configuration>;
+
     if (!result.ok) {
       Logger.getInstance().logBot(
         new Error(
-          `Failed to get configuration for server ${id}: ${result.statusText}`,
+          `Failed to get configuration for server ${id}: ${json.error}`,
         ),
       );
 
       return null;
     }
 
-    const json = await result.json();
-    return json['data'] as Configuration | null;
+    return json.data;
   }
 
   public async createConfig(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,6 +2129,11 @@ data-uri-to-buffer@3:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -2827,6 +2832,14 @@ fclone@1.0.11, fclone@~1.0.11:
   resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
   integrity sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.4.tgz#e8c6567f80ad7fc22fd302e7dcb72bafde9c1717"
+  integrity sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -2918,6 +2931,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -4690,12 +4710,26 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.6.1, node-fetch@~2.6.1:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.0.tgz#59390db4e489184fa35d4b74caf5510e8dfbaf3b"
+  integrity sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -6613,6 +6647,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Overview

This pull request bumps `node-fetch` as an attempt to fix [security vulnerabilities](https://github.com/Namchee/pleasantcord/pull/63). This pull request also enforces `APIResponse` type when fetching data from API as the signature changed from `Promise<any>` to `Promise<unknown>`.