### PR TITLE
feat: add slash commands

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,11 @@ jobs:
         run: yarn lint:fix
       - name: Build the files
         run: yarn build
+      - name: Register slash commands
+        run: node scripts/slash.js
+        env:
+          DISCORD_ID: ${{ secrets.DISCORD_ID }}
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
       - name: Reload the bot
         run: yarn restart
       

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This bot aims to fix that by automatically detecting potential NSFW images and a
 
 ## Installation
 
-Invite this bot to your server by clicking [this link](https://discord.com/api/oauth2/authorize?client_id=750668307555942482&permissions=10240&scope=bot).
+Invite this bot to your server by clicking [this link](https://discord.com/api/oauth2/authorize?client_id=750668307555942482&permissions=10240&scope=applications.commands%20bot).
 
 The bot itself requires the following permission in your server, make sure that the bot has **all** the permissions below:
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cheerio": "^1.0.0-rc.10",
     "discord-api-types": "^0.27.2",
     "discord.js": "^13.1.0",
-    "dotenv": "^10.0.0",
+    "dotenv": "^16.0.0",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.7",
     "nsfwjs": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,14 @@
     "vitest": "^0.2.6"
   },
   "dependencies": {
+    "@discordjs/builders": "^0.12.0",
+    "@discordjs/rest": "^0.3.0",
     "@ffmpeg/core": "^0.10.0",
     "@ffmpeg/ffmpeg": "^0.10.1",
     "@sentry/node": "^6.11.0",
     "@tensorflow/tfjs-node": "^3.11.0",
     "cheerio": "^1.0.0-rc.10",
+    "discord-api-types": "^0.27.2",
     "discord.js": "^13.1.0",
     "dotenv": "^10.0.0",
     "node-cache": "^5.1.2",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,4 +5,5 @@ module.exports = {
   arrowParens: 'avoid',
   parser: 'typescript',
   endOfLine: 'auto',
+  tabWidth: 2,
 };

--- a/scripts/slash.js
+++ b/scripts/slash.js
@@ -1,30 +1,40 @@
 // @ts-check
-import { SlashCommandBuilder } from '@discordjs/builders';
-import { REST } from '@discordjs/rest';
-import { Routes } from 'discord-api-types/v9';
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { REST } = require('@discordjs/rest');
+const { Routes } = require('discord-api-types/v9');
 
 if (!process.env.DISCORD_TOKEN || !process.env.DISCORD_ID) {
   throw new Error('Missing token or client id');
 }
 
 (async () => {
-  const commands = [
-    new SlashCommandBuilder()
-      .setName('config')
-      .setDescription("Show pleasantcord's configuration for this guild"),
-    new SlashCommandBuilder()
-      .setName('status')
-      .setDescription("Show pleasantcord's global status"),
-    new SlashCommandBuilder()
-      .setName('help')
-      .setDescription('Show the help menu of pleasantcord'),
-  ].map(cmd => cmd.toJSON());
+  try {
+    const commands = [
+      new SlashCommandBuilder()
+        .setName('config')
+        .setDescription("Show pleasantcord's configuration for this guild"),
+      new SlashCommandBuilder()
+        .setName('status')
+        .setDescription("Show pleasantcord's global status"),
+      new SlashCommandBuilder()
+        .setName('help')
+        .setDescription('Show the help menu of pleasantcord'),
+    ].map(cmd => cmd.toJSON());
 
-  const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN);
+    const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN);
 
-  await rest.put(Routes.applicationCommands(process.env.DISCORD_ID), {
-    body: commands,
-  });
+    await rest.put(
+      Routes.applicationGuildCommands(
+        process.env.DISCORD_ID,
+        '871723788599980084'
+      ),
+      {
+        body: commands,
+      }
+    );
 
-  console.log('Command has been registered successfully');
+    console.log('Command has been registered successfully');
+  } catch (err) {
+    console.error(err);
+  }
 })();

--- a/scripts/slash.js
+++ b/scripts/slash.js
@@ -1,0 +1,30 @@
+// @ts-check
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v9';
+
+if (!process.env.DISCORD_TOKEN || !process.env.DISCORD_ID) {
+  throw new Error('Missing token or client id');
+}
+
+(async () => {
+  const commands = [
+    new SlashCommandBuilder()
+      .setName('config')
+      .setDescription("Show pleasantcord's configuration for this guild"),
+    new SlashCommandBuilder()
+      .setName('status')
+      .setDescription("Show pleasantcord's global status"),
+    new SlashCommandBuilder()
+      .setName('help')
+      .setDescription('Show the help menu of pleasantcord'),
+  ].map(cmd => cmd.toJSON());
+
+  const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN);
+
+  await rest.put(Routes.applicationCommands(process.env.DISCORD_ID), {
+    body: commands,
+  });
+
+  console.log('Command has been registered successfully');
+})();

--- a/scripts/slash.js
+++ b/scripts/slash.js
@@ -23,15 +23,9 @@ if (!process.env.DISCORD_TOKEN || !process.env.DISCORD_ID) {
 
     const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN);
 
-    await rest.put(
-      Routes.applicationGuildCommands(
-        process.env.DISCORD_ID,
-        '871723788599980084'
-      ),
-      {
-        body: commands,
-      }
-    );
+    await rest.put(Routes.applicationCommands(process.env.DISCORD_ID), {
+      body: commands,
+    });
 
     console.log('Command has been registered successfully');
   } catch (err) {

--- a/scripts/slash.ts
+++ b/scripts/slash.ts
@@ -1,3 +1,0 @@
-import { SlashCommandBuilder } from '@discordjs/builders';
-import { REST } from '@discordjs/rest';
-import { Routes } from 'discord-api-types/v9';

--- a/scripts/slash.ts
+++ b/scripts/slash.ts
@@ -1,0 +1,3 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v9';

--- a/src/bot/commands/config.ts
+++ b/src/bot/commands/config.ts
@@ -1,22 +1,23 @@
-import { Message, MessageEmbed } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
 
 import { BLUE, ORANGE } from '../../constants/color';
 
-import { BotContext } from '../types';
+import { BotContext, CommandHandlerParams } from '../types';
 
 export default {
   command: 'config',
   description: 'Show configuration for the current server',
-  fn: async ({ service }: BotContext, msg: Message): Promise<Message> => {
-    const { channel, guild } = msg;
-
-    const config = await service.getConfig(guild?.id as string);
+  fn: async (
+    { service }: BotContext,
+    { guild }: CommandHandlerParams
+  ): Promise<MessageEmbed> => {
+    const config = await service.getConfig(guild.id);
 
     if (!config) {
-      throw new Error(`Failed to get configuration for server ${msg.guildId}`);
+      throw new Error(`Failed to get configuration for server ${guild.id}`);
     }
 
-    const embed = new MessageEmbed({
+    return new MessageEmbed({
       author: {
         name: 'pleasantcord',
         iconURL: process.env.IMAGE_URL,
@@ -49,7 +50,5 @@ export default {
       ],
       color: process.env.NODE_ENV === 'development' ? BLUE : ORANGE,
     });
-
-    return channel.send({ embeds: [embed] });
   },
 };

--- a/src/bot/commands/help.ts
+++ b/src/bot/commands/help.ts
@@ -1,22 +1,21 @@
-import { Message, MessageEmbed } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
 
-import { BLUE, ORANGE } from '../../constants/color';
 import { getCommands } from '../utils';
 
-import type { BotContext, CommandHandler } from '../types';
+import { BLUE, ORANGE } from '../../constants/color';
+
+import type { CommandHandler } from '../types';
 
 export default {
   command: 'help',
   description: 'Show the help message',
-  fn: (_: BotContext, msg: Message): Promise<Message> => {
-    const { channel } = msg;
-
+  fn: async (): Promise<MessageEmbed> => {
     const rawCommands = getCommands();
     const commands = rawCommands.map((command: CommandHandler) => {
       return `\`pc!${command.command}\` — ${command.description}`;
     });
 
-    const embed = new MessageEmbed({
+    return new MessageEmbed({
       author: {
         name: 'pleasantcord',
         iconURL: process.env.IMAGE_URL,
@@ -43,7 +42,5 @@ export default {
       ],
       color: process.env.NODE_ENV === 'development' ? BLUE : ORANGE,
     });
-
-    return channel.send({ embeds: [embed] });
   },
 };

--- a/src/bot/commands/status.ts
+++ b/src/bot/commands/status.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
-import { Message, MessageEmbed } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
 
-import { BotContext } from '../types';
+import { BotContext, CommandHandlerParams } from '../types';
 import { BLUE, ORANGE } from '../../constants/color';
 
 const packageInfo = require(resolve(process.cwd(), 'package.json'));
@@ -9,8 +9,11 @@ const packageInfo = require(resolve(process.cwd(), 'package.json'));
 export default {
   command: 'status',
   description: 'Show the bot status',
-  fn: async ({ client }: BotContext, msg: Message): Promise<Message> => {
-    const time = Date.now() - msg.createdTimestamp;
+  fn: async (
+    { client }: BotContext,
+    { timestamp }: CommandHandlerParams
+  ): Promise<MessageEmbed> => {
+    const time = Date.now() - timestamp;
 
     let packageVersion: string = packageInfo.dependencies['discord.js'];
 
@@ -39,7 +42,7 @@ export default {
       },
     ];
 
-    const embed: MessageEmbed = new MessageEmbed({
+    return new MessageEmbed({
       author: {
         name: 'pleasantcord',
         iconURL: process.env.IMAGE_URL,
@@ -48,7 +51,5 @@ export default {
       fields,
       color: process.env.NODE_ENV === 'development' ? BLUE : ORANGE,
     });
-
-    return msg.channel.send({ embeds: [embed] });
   },
 };

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -7,7 +7,7 @@ import type { BotContext } from './../types';
 
 export default {
   event: 'guildCreate',
-  fn: async ({ service }: BotContext, guild: Guild): Promise<void> => {
+  fn: async ({ client, service }: BotContext, guild: Guild): Promise<void> => {
     try {
       // create guild config when the bot enters a guild.
       await service.createConfig(guild.id, BASE_CONFIG);

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -7,7 +7,7 @@ import type { BotContext } from './../types';
 
 export default {
   event: 'guildCreate',
-  fn: async ({ client, service }: BotContext, guild: Guild): Promise<void> => {
+  fn: async ({ service }: BotContext, guild: Guild): Promise<void> => {
     try {
       // create guild config when the bot enters a guild.
       await service.createConfig(guild.id, BASE_CONFIG);

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -1,18 +1,32 @@
-import { Guild } from 'discord.js';
+import { Guild, MessageEmbed, TextChannel } from 'discord.js';
 
 import { BASE_CONFIG } from './../../entity/config';
 import { handleError } from './../utils';
 
 import type { BotContext } from './../types';
+import { Credentials, registerSlashCommands } from '../service/command';
 
 export default {
   event: 'guildCreate',
-  fn: async ({ service }: BotContext, guild: Guild): Promise<void> => {
+  fn: async ({ client, service }: BotContext, guild: Guild): Promise<void> => {
     try {
       // create guild config when the bot enters a guild.
       await service.createConfig(guild.id, BASE_CONFIG);
+      // register slash commands for the new guild
+      const creds: Credentials = {
+        clientID: client.application?.id as string,
+        token: client.token as string,
+      };
+
+      return registerSlashCommands(guild.id, creds);
     } catch (err) {
-      handleError(err as Error);
+      const embed = handleError(err as Error) as MessageEmbed;
+
+      const defaultChannel = guild.channels.cache.find(
+        chan => chan.name.toLowerCase() === 'general'
+      ) as TextChannel;
+
+      await defaultChannel.send({ embeds: [embed] });
     }
   },
 };

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -1,10 +1,14 @@
 import { Guild, MessageEmbed, TextChannel } from 'discord.js';
 
+import { Credentials, registerSlashCommands } from '../service/command';
+
 import { BASE_CONFIG } from './../../entity/config';
+
 import { handleError } from './../utils';
 
 import type { BotContext } from './../types';
-import { Credentials, registerSlashCommands } from '../service/command';
+
+import { DEFAULT_CHANNEL } from './../../constants/channel';
 
 export default {
   event: 'guildCreate',
@@ -23,7 +27,7 @@ export default {
       const embed = handleError(err as Error) as MessageEmbed;
 
       const defaultChannel = guild.channels.cache.find(
-        chan => chan.name.toLowerCase() === 'general'
+        chan => chan.name.toLowerCase() === DEFAULT_CHANNEL
       ) as TextChannel;
 
       await defaultChannel.send({ embeds: [embed] });

--- a/src/bot/events/interactionCreate.ts
+++ b/src/bot/events/interactionCreate.ts
@@ -1,0 +1,35 @@
+import { Interaction, MessageEmbed, TextChannel } from 'discord.js';
+
+import { UNKNOWN_COMMAND_EMBED } from './../../constants/embeds';
+import { BotContext, CommandHandlerParams } from '../types';
+
+import { getCommandMap } from '../utils';
+
+export default {
+  event: 'interactionCreate',
+  fn: async (ctx: BotContext, interaction: Interaction) => {
+    if (
+      !interaction.isCommand() ||
+      !interaction.guild ||
+      !interaction.channel?.isText()
+    ) {
+      return;
+    }
+
+    const commandMap = getCommandMap();
+    const handler = commandMap[interaction.commandName];
+
+    let embed: MessageEmbed = UNKNOWN_COMMAND_EMBED;
+
+    if (handler) {
+      const params: CommandHandlerParams = {
+        guild: interaction.guild,
+        channel: interaction.channel as TextChannel,
+        timestamp: interaction.createdTimestamp,
+      };
+      embed = await handler(ctx, params);
+    }
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+};

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -1,6 +1,5 @@
-import { Message, MessageEmbed } from 'discord.js';
+import { Message, MessageEmbed, TextChannel } from 'discord.js';
 
-import { RED } from '../../constants/color';
 import { PREFIX } from '../../constants/command';
 
 import {
@@ -10,7 +9,13 @@ import {
   moderateContent,
 } from '../utils';
 
-import { CommandHandler, BotContext, CommandHandlerFunction } from '../types';
+import {
+  CommandHandler,
+  BotContext,
+  CommandHandlerFunction,
+  CommandHandlerParams,
+} from '../types';
+import { UNKNOWN_COMMAND_EMBED } from '@/constants/embeds';
 
 /**
  * Get all available commands from command files and
@@ -36,24 +41,18 @@ export default {
 
       if (msg.content.startsWith(PREFIX)) {
         const commandHandler = commandMap[getCommand(msg.content)];
+        let embed: MessageEmbed = UNKNOWN_COMMAND_EMBED;
 
         if (commandHandler) {
-          return commandHandler(ctx, msg);
+          const params: CommandHandlerParams = {
+            guild: msg.guild,
+            channel: msg.channel as TextChannel,
+            timestamp: msg.createdTimestamp,
+          };
+          embed = await commandHandler(ctx, params);
         }
 
-        const unknownEmbed = new MessageEmbed({
-          author: {
-            name: 'pleasantcord',
-            iconURL: process.env.IMAGE_URL,
-          },
-          color: RED,
-          title: 'Unknown Command',
-          description:
-            // eslint-disable-next-line max-len
-            `**pleasantcord** doesn't recognize the command that have been just sent.\nPlease refer to **${PREFIX}help** to show all available **pleasantcords's** commands.`,
-        });
-
-        return msg.channel.send({ embeds: [unknownEmbed] });
+        return msg.channel.send({ embeds: [embed] });
       }
 
       return moderateContent(ctx, msg);

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -1,11 +1,8 @@
 import { Message, MessageEmbed, TextChannel } from 'discord.js';
 
-import {
-  handleError,
-  getMessageCommand,
-  moderateContent,
-  getCommandMap,
-} from '../utils';
+import { moderateContent } from '../service/classifier';
+
+import { handleError, getMessageCommand, getCommandMap } from '../utils';
 
 import { BotContext, CommandHandlerParams } from '../types';
 

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -1,7 +1,5 @@
 import { Message, MessageEmbed, TextChannel } from 'discord.js';
 
-import { PREFIX } from '../../constants/command';
-
 import {
   handleError,
   getCommands,
@@ -15,7 +13,9 @@ import {
   CommandHandlerFunction,
   CommandHandlerParams,
 } from '../types';
-import { UNKNOWN_COMMAND_EMBED } from '@/constants/embeds';
+
+import { PREFIX } from '../../constants/command';
+import { UNKNOWN_COMMAND_EMBED } from '../../constants/embeds';
 
 /**
  * Get all available commands from command files and

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -2,31 +2,15 @@ import { Message, MessageEmbed, TextChannel } from 'discord.js';
 
 import {
   handleError,
-  getCommands,
-  getCommand,
+  getMessageCommand,
   moderateContent,
+  getCommandMap,
 } from '../utils';
 
-import {
-  CommandHandler,
-  BotContext,
-  CommandHandlerFunction,
-  CommandHandlerParams,
-} from '../types';
+import { BotContext, CommandHandlerParams } from '../types';
 
 import { PREFIX } from '../../constants/command';
 import { UNKNOWN_COMMAND_EMBED } from '../../constants/embeds';
-
-/**
- * Get all available commands from command files and
- * register all commands to a simple object map.
- */
-const commandMap: Record<string, CommandHandlerFunction> = {};
-const commandHandlers = getCommands();
-
-commandHandlers.forEach((handler: CommandHandler) => {
-  commandMap[handler.command] = handler.fn;
-});
 
 export default {
   event: 'messageCreate',
@@ -40,16 +24,17 @@ export default {
       }
 
       if (msg.content.startsWith(PREFIX)) {
-        const commandHandler = commandMap[getCommand(msg.content)];
+        const commandMap = getCommandMap();
+        const handler = commandMap[getMessageCommand(msg.content)];
         let embed: MessageEmbed = UNKNOWN_COMMAND_EMBED;
 
-        if (commandHandler) {
+        if (handler) {
           const params: CommandHandlerParams = {
             guild: msg.guild,
             channel: msg.channel as TextChannel,
             timestamp: msg.createdTimestamp,
           };
-          embed = await commandHandler(ctx, params);
+          embed = await handler(ctx, params);
         }
 
         return msg.channel.send({ embeds: [embed] });

--- a/src/bot/events/messageUpdate.ts
+++ b/src/bot/events/messageUpdate.ts
@@ -1,6 +1,8 @@
 import { Message } from 'discord.js';
 
-import { handleError, moderateContent } from '../utils';
+import { moderateContent } from '../service/classifier';
+
+import { handleError } from '../utils';
 
 import { BotContext } from '../types';
 

--- a/src/bot/service/classifier.ts
+++ b/src/bot/service/classifier.ts
@@ -1,0 +1,196 @@
+import { Message, TextChannel, MessageEmbed } from 'discord.js';
+import { FunctionThread, Pool, spawn, Worker } from 'threads';
+import { QueuedTask } from 'threads/dist/master/pool-types';
+
+import { Classifier } from './../../service/workers';
+
+import { BASE_CONFIG } from './../../entity/config';
+import { Content } from './../../entity/content';
+
+import { BLUE, ORANGE } from './../../constants/color';
+
+import { BotContext, ClassificationResult } from '../types';
+
+import { getSupportedContents } from '../utils';
+import { Logger } from './../../utils/logger';
+
+export const workers = Pool(() =>
+  spawn<Classifier>(new Worker('../../service/workers'))
+);
+
+/**
+ * Check all supported content for NSFW contents
+ * and react accordingly.
+ *
+ * @param {BotContext} ctx bot context
+ * @param {Message} msg discord's message object
+ * @returns {Promise<void>}
+ */
+export async function moderateContent(
+  { service, rateLimiter }: BotContext,
+  msg: Message
+): Promise<void> {
+  const channel = msg.channel as TextChannel;
+
+  if (channel.nsfw) {
+    return;
+  }
+
+  const contents: Content[] = getSupportedContents(msg);
+
+  if (contents.length === 0) {
+    return;
+  }
+
+  const isDev = process.env.NODE_ENV !== 'production';
+  const rateLimitKey = `${msg.guildId as string}:${msg.channelId}`;
+
+  if (rateLimiter.isRateLimited(rateLimitKey) && !isDev) {
+    return;
+  }
+
+  rateLimiter.rateLimit(rateLimitKey);
+
+  let config = BASE_CONFIG;
+
+  const realConfig = await service.getConfig(msg.guildId as string);
+
+  if (realConfig) {
+    config = realConfig;
+  } else {
+    Logger.getInstance().logBot(
+      new Error(`Failed to get configuration for server ${msg.guildId}}`)
+    );
+  }
+
+  const tasks: QueuedTask<FunctionThread, ClassificationResult>[] = [];
+
+  contents.forEach(({ name, url }) => {
+    const classification = workers.queue(async classifier => {
+      let start = 0;
+
+      if (isDev) {
+        start = performance.now();
+      }
+
+      const categories = await classifier(url, config.model);
+
+      return {
+        name,
+        source: url,
+        categories,
+        time: isDev ? performance.now() - start : undefined,
+      };
+    });
+
+    tasks.push(classification);
+  });
+
+  for await (const { name, source, categories, time } of tasks) {
+    if (!categories.length) {
+      continue;
+    }
+
+    const nsfwCategory = categories.find(cat => {
+      return (
+        config.categories.includes(cat.name) && cat.accuracy >= config.accuracy
+      );
+    });
+
+    const promises = [];
+
+    if (nsfwCategory) {
+      // make sure that all queued tasks are killed
+      tasks.forEach(t => t.cancel());
+
+      const fields = [
+        {
+          name: 'Author',
+          value: msg.author.toString(),
+        },
+        {
+          name: 'Category',
+          value: nsfwCategory.name,
+          inline: true,
+        },
+        {
+          name: 'Accuracy',
+          value: `${(nsfwCategory.accuracy * 100).toFixed(2)}%`,
+          inline: true,
+        },
+      ];
+
+      if (msg.content) {
+        fields.push({
+          name: 'Contents',
+          value: msg.content,
+          inline: false,
+        });
+      }
+
+      const embed = new MessageEmbed({
+        author: {
+          name: 'pleasantcord',
+          iconURL: process.env.IMAGE_URL,
+        },
+        title: 'Possible NSFW Contents Detected',
+        fields,
+        color: process.env.NODE_ENV !== 'production' ? BLUE : ORANGE,
+      });
+
+      promises.push(channel.send({ embeds: [embed] }));
+
+      const files = [];
+
+      if (!config.delete) {
+        files.push({
+          attachment: source,
+          name: `SPOILER_${name}`,
+        });
+
+        promises.push(channel.send({ files }));
+      }
+
+      if (msg.deletable) {
+        promises.push(msg.delete());
+      }
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      const devEmbed = new MessageEmbed({
+        author: {
+          name: 'pleasantcord',
+          iconURL: process.env.IMAGE_URL,
+        },
+        title: '[DEV] Image Labels',
+        fields: [
+          {
+            name: 'Labels',
+            value: categories
+              .map(({ name, accuracy }) => {
+                return `${name} — ${(accuracy * 100).toFixed(2)}%`;
+              })
+              .join('\n'),
+          },
+          {
+            name: 'Elapsed Time',
+            value: `${(time as number).toFixed(2)} ms`,
+          },
+          {
+            name: 'Model',
+            value: config.model,
+          },
+        ],
+        color: BLUE,
+      });
+
+      promises.push(channel.send({ embeds: [devEmbed] }));
+    }
+
+    await Promise.all(promises);
+
+    if (nsfwCategory) {
+      break;
+    }
+  }
+}

--- a/src/bot/service/command.ts
+++ b/src/bot/service/command.ts
@@ -1,0 +1,44 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v9';
+
+export interface Credentials {
+  clientID: string;
+  token: string;
+}
+
+/**
+ * Register slash commands for a guild
+ *
+ * @param {string} guildID guild ID
+ * @param {Credentials} creds Bot's credentials
+ * @param {string} creds.clientID Discord's client ID
+ * @param {string} creds.token Discord's bot token
+ */
+export async function registerSlashCommands(
+  guildID: string,
+  { clientID, token }: Credentials
+): Promise<void> {
+  try {
+    const commands = [
+      new SlashCommandBuilder()
+        .setName('config')
+        .setDescription("Show pleasantcord's configuration for this guild"),
+      new SlashCommandBuilder()
+        .setName('status')
+        .setDescription("Show pleasantcord's global status"),
+      new SlashCommandBuilder()
+        .setName('help')
+        .setDescription('Show the help menu of pleasantcord'),
+    ].map(cmd => cmd.toJSON());
+
+    const rest = new REST({ version: '9' }).setToken(token);
+
+    await rest.put(Routes.applicationGuildCommands(clientID, guildID), {
+      body: commands,
+    });
+  } catch (err) {
+    const { message } = err as Error;
+    throw new Error(`Failed to register slash commands: ${message}`);
+  }
+}

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -1,4 +1,11 @@
-import { Client, ClientEvents, Message } from 'discord.js';
+import {
+  Client,
+  ClientEvents,
+  Guild,
+  Message,
+  MessageEmbed,
+  TextChannel,
+} from 'discord.js';
 
 import { ConfigurationService } from '../service/config';
 import { RateLimiter } from '../service/rate-limit';
@@ -18,15 +25,23 @@ export interface EventHandler {
   fn: (ctx: BotContext) => Promise<void>;
 }
 
+// Required parameters for command handlers
+export interface CommandHandlerParams {
+  guild: Guild;
+  channel: TextChannel;
+  timestamp: number;
+}
+
 /**
  * Command handler function.
  * Used in `messageCreate` event when the message
- * is prefixed with `pc!` with the correct command.
+ * is prefixed with `pc!` with the correct command OR
+ * on `interactionCreate` with slash commands
  */
 export type CommandHandlerFunction = (
   ctx: BotContext,
-  msg: Message
-) => Promise<void>;
+  params: CommandHandlerParams
+) => Promise<MessageEmbed>;
 
 /**
  * Command handler.

--- a/src/bot/utils.test.ts
+++ b/src/bot/utils.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, afterEach, beforeEach, vi, expect } from 'vitest';
 import { Constants, Message, MessageEmbed } from 'discord.js';
 
-import { getCommand, getSupportedContents, handleError } from '@/bot/utils';
+import {
+  getMessageCommand,
+  getSupportedContents,
+  handleError,
+} from '@/bot/utils';
 import { Logger } from '@/utils/logger';
 import { RED } from '@/constants/color';
 import { PLACEHOLDER_NAME } from '@/constants/content';
@@ -120,14 +124,14 @@ describe('handleError', () => {
 describe('getCommand', () => {
   it('should return actual command', () => {
     const msg = 'pc!help';
-    const cmd = getCommand(msg);
+    const cmd = getMessageCommand(msg);
 
     expect(cmd).toBe('help');
   });
 
   it('should get the first argument only', () => {
     const msg = 'pc!help lorem ipsum';
-    const cmd = getCommand(msg);
+    const cmd = getMessageCommand(msg);
 
     expect(cmd).toBe('help');
   });

--- a/src/bot/utils.ts
+++ b/src/bot/utils.ts
@@ -1,32 +1,17 @@
 import { readdirSync } from 'fs';
 import { resolve } from 'path';
-import { Constants, Message, MessageEmbed, TextChannel } from 'discord.js';
-
-import { Pool, spawn, FunctionThread, Worker } from 'threads';
-import { QueuedTask } from 'threads/dist/master/pool-types';
+import { Constants, Message, MessageEmbed } from 'discord.js';
 
 import { Content } from '../entity/content';
 
-import {
-  BotContext,
-  ClassificationResult,
-  CommandHandler,
-  CommandHandlerFunction,
-  EventHandler,
-} from './types';
-
-import { Classifier } from './../service/workers';
-
-import { BASE_CONFIG } from './../entity/config';
+import { CommandHandler, CommandHandlerFunction, EventHandler } from './types';
 
 import { PERMISSION_ERRORS } from '../constants/error';
-import { BLUE, ORANGE, RED } from '../constants/color';
+import { RED } from '../constants/color';
 import { PREFIX } from '../constants/command';
 import { CLASSIFIABLE_CONTENTS, PLACEHOLDER_NAME } from '../constants/content';
 
 import { Logger } from '../utils/logger';
-
-const workers = Pool(() => spawn<Classifier>(new Worker('../service/workers')));
 
 // this cannot be tested at the moment. Context: https://github.com/vitest-dev/vitest/issues/110
 /* c8 ignore start */
@@ -191,181 +176,4 @@ export function getSupportedContents(msg: Message): Content[] {
   });
 
   return contents;
-}
-
-/**
- * Check all supported content for NSFW contents
- * and react accordingly.
- *
- * @param {BotContext} ctx bot context
- * @param {Message} msg discord's message object
- * @returns {Promise<void>}
- */
-export async function moderateContent(
-  { service, rateLimiter }: BotContext,
-  msg: Message
-): Promise<void> {
-  const channel = msg.channel as TextChannel;
-
-  if (channel.nsfw) {
-    return;
-  }
-
-  const contents: Content[] = getSupportedContents(msg);
-
-  if (contents.length === 0) {
-    return;
-  }
-
-  const isDev = process.env.NODE_ENV !== 'production';
-  const rateLimitKey = `${msg.guildId as string}:${msg.channelId}`;
-
-  if (rateLimiter.isRateLimited(rateLimitKey) && !isDev) {
-    return;
-  }
-
-  rateLimiter.rateLimit(rateLimitKey);
-
-  let config = BASE_CONFIG;
-
-  const realConfig = await service.getConfig(msg.guildId as string);
-
-  if (realConfig) {
-    config = realConfig;
-  } else {
-    Logger.getInstance().logBot(
-      new Error(`Failed to get configuration for server ${msg.guildId}}`)
-    );
-  }
-
-  const tasks: QueuedTask<FunctionThread, ClassificationResult>[] = [];
-
-  contents.forEach(({ name, url }) => {
-    const classification = workers.queue(async classifier => {
-      let start = 0;
-
-      if (isDev) {
-        start = performance.now();
-      }
-
-      const categories = await classifier(url, config.model);
-
-      return {
-        name,
-        source: url,
-        categories,
-        time: isDev ? performance.now() - start : undefined,
-      };
-    });
-
-    tasks.push(classification);
-  });
-
-  for await (const { name, source, categories, time } of tasks) {
-    if (!categories.length) {
-      continue;
-    }
-
-    const nsfwCategory = categories.find(cat => {
-      return (
-        config.categories.includes(cat.name) && cat.accuracy >= config.accuracy
-      );
-    });
-
-    const promises = [];
-
-    if (nsfwCategory) {
-      // make sure that all queued tasks are killed
-      tasks.forEach(t => t.cancel());
-
-      const fields = [
-        {
-          name: 'Author',
-          value: msg.author.toString(),
-        },
-        {
-          name: 'Category',
-          value: nsfwCategory.name,
-          inline: true,
-        },
-        {
-          name: 'Accuracy',
-          value: `${(nsfwCategory.accuracy * 100).toFixed(2)}%`,
-          inline: true,
-        },
-      ];
-
-      if (msg.content) {
-        fields.push({
-          name: 'Contents',
-          value: msg.content,
-          inline: false,
-        });
-      }
-
-      const embed = new MessageEmbed({
-        author: {
-          name: 'pleasantcord',
-          iconURL: process.env.IMAGE_URL,
-        },
-        title: 'Possible NSFW Contents Detected',
-        fields,
-        color: process.env.NODE_ENV !== 'production' ? BLUE : ORANGE,
-      });
-
-      promises.push(channel.send({ embeds: [embed] }));
-
-      const files = [];
-
-      if (!config.delete) {
-        files.push({
-          attachment: source,
-          name: `SPOILER_${name}`,
-        });
-
-        promises.push(channel.send({ files }));
-      }
-
-      if (msg.deletable) {
-        promises.push(msg.delete());
-      }
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-      const devEmbed = new MessageEmbed({
-        author: {
-          name: 'pleasantcord',
-          iconURL: process.env.IMAGE_URL,
-        },
-        title: '[DEV] Image Labels',
-        fields: [
-          {
-            name: 'Labels',
-            value: categories
-              .map(({ name, accuracy }) => {
-                return `${name} — ${(accuracy * 100).toFixed(2)}%`;
-              })
-              .join('\n'),
-          },
-          {
-            name: 'Elapsed Time',
-            value: `${(time as number).toFixed(2)} ms`,
-          },
-          {
-            name: 'Model',
-            value: config.model,
-          },
-        ],
-        color: BLUE,
-      });
-
-      promises.push(channel.send({ embeds: [devEmbed] }));
-    }
-
-    await Promise.all(promises);
-
-    if (nsfwCategory) {
-      break;
-    }
-  }
 }

--- a/src/bot/utils.ts
+++ b/src/bot/utils.ts
@@ -11,6 +11,7 @@ import {
   BotContext,
   ClassificationResult,
   CommandHandler,
+  CommandHandlerFunction,
   EventHandler,
 } from './types';
 
@@ -32,6 +33,7 @@ const workers = Pool(() => spawn<Classifier>(new Worker('../service/workers')));
 
 // cache this
 let commandList: CommandHandler[];
+let commandMap: Record<string, CommandHandlerFunction>;
 
 /**
  * Get all available commands from command files.
@@ -57,6 +59,24 @@ export function getCommands(): CommandHandler[] {
   }
 
   return commandList;
+}
+
+/**
+ * Get command map for user interaction.
+ *
+ * @returns {Record<string, CommandHandlerFunction>} mapped commands
+ */
+export function getCommandMap(): Record<string, CommandHandlerFunction> {
+  if (!commandMap) {
+    const commands = getCommands();
+    commandMap = {};
+
+    commands.forEach((handler: CommandHandler) => {
+      commandMap[handler.command] = handler.fn;
+    });
+  }
+
+  return commandMap;
 }
 
 /**
@@ -137,7 +157,7 @@ export function handleError(err: Error): MessageEmbed | null {
  * @param {string} msg user message
  * @returns {string} command name
  */
-export function getCommand(msg: string): string {
+export function getMessageCommand(msg: string): string {
   return msg.slice(PREFIX.length).trim().split(/ +/)[0];
 }
 

--- a/src/constants/channel.ts
+++ b/src/constants/channel.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_CHANNEL = 'general';

--- a/src/constants/embeds.ts
+++ b/src/constants/embeds.ts
@@ -1,0 +1,16 @@
+import { MessageEmbed } from 'discord.js';
+
+import { RED } from './color';
+import { PREFIX } from './command';
+
+export const UNKNOWN_COMMAND_EMBED = new MessageEmbed({
+  author: {
+    name: 'pleasantcord',
+    iconURL: process.env.IMAGE_URL,
+  },
+  color: RED,
+  title: 'Unknown Command',
+  description:
+    // eslint-disable-next-line max-len
+    `**pleasantcord** doesn't recognize the command that have been just sent.\nPlease refer to **${PREFIX}help** to show all available **pleasantcords's** commands.`,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,20 @@ import { config } from 'dotenv';
 
 import NodeCache from 'node-cache';
 
-import { Logger } from './utils/logger';
 import { bootstrapBot } from './bot';
+import { workers } from './bot/service/classifier';
+
+import { ConfigurationService } from './service/config';
+import { LocalRateLimiter } from './service/rate-limit';
+
 import {
   CloudflareConfigurationRepository,
   LocalConfigurationCache,
 } from './repository/config';
+
+import { Logger } from './utils/logger';
+
 import { FIVE_MINUTES, THREE_SECONDS } from './constants/time';
-import { ConfigurationService } from './service/config';
-import { LocalRateLimiter } from './service/rate-limit';
 
 if (process.env.NODE_ENV === 'development') {
   config();
@@ -46,6 +51,7 @@ if (process.env.NODE_ENV === 'development') {
 
   const cleanup = async (): Promise<void> => {
     client.destroy();
+    workers.terminate();
     await Logger.getInstance().closeLogger();
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,10 +51,34 @@
     tslib "^2.3.1"
     zod "^3.11.6"
 
+"@discordjs/builders@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.12.0.tgz#5f6d95d1b231fa975a7e28ca3f8098e517676887"
+  integrity sha512-Vx2MjUZd6QVo1uS2uWt708Fd6cHWGFblAvbpL5EBO+kLl0BADmPwwvts+YJ/VfSywed6Vsk6K2cEooR/Ytjhjw==
+  dependencies:
+    "@sindresorhus/is" "^4.3.0"
+    discord-api-types "^0.26.1"
+    ts-mixer "^6.0.0"
+    tslib "^2.3.1"
+    zod "^3.11.6"
+
 "@discordjs/collection@^0.4.0":
   version "0.4.0"
   resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz"
   integrity sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==
+
+"@discordjs/rest@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-0.3.0.tgz#89e06a42b168c91598891d6bf860353e28fba5d2"
+  integrity sha512-F9aeP3odlAlllM1ciBZLdd+adiAyBj4VaZBejj4UMj4afE2wfCkNTGvYYiRxrXUE9fN7e/BuDP2ePl0tVA2m7Q==
+  dependencies:
+    "@discordjs/collection" "^0.4.0"
+    "@sapphire/async-queue" "^1.1.9"
+    "@sapphire/snowflake" "^3.0.1"
+    discord-api-types "^0.26.1"
+    form-data "^4.0.0"
+    node-fetch "^2.6.5"
+    tslib "^2.3.1"
 
 "@es-joy/jsdoccomment@~0.17.0":
   version "0.17.0"
@@ -283,6 +307,11 @@
   resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz"
   integrity sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==
 
+"@sapphire/snowflake@^3.0.1":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.1.0.tgz#1c2d9781d3b1de0bcb02b7079898947ce754d394"
+  integrity sha512-K+OiqXSx4clIaXcoaghrCV56zsm3bZZ5SBpgJkgvAKegFFdETMntHviUfypjt8xVleIuDaNyQA4APOIl3BMcxg==
+
 "@sentry/core@6.16.1":
   version "6.16.1"
   resolved "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz"
@@ -360,6 +389,11 @@
   version "4.3.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.3.0.tgz"
   integrity sha512-wwOvh0eO3PiTEivGJWiZ+b946SlMSb4pe+y+Ur/4S87cwo09pYi+FWHHnbrM3W9W7cBYKDqQXcrFYjYUCOJUEQ==
+
+"@sindresorhus/is@^4.3.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.4.0.tgz#e277e5bdbdf7cb1e20d320f02f5e2ed113cd3185"
+  integrity sha512-QppPM/8l3Mawvh4rn9CNEYIU9bxpXUCRMaX9yUpvBk1nMKusLKpfXGDEKExKaPhLzcn3lzil7pR6rnJ11HgeRQ==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -1539,10 +1573,15 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-api-types@^0.26.0:
+discord-api-types@^0.26.0, discord-api-types@^0.26.1:
   version "0.26.1"
   resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz"
   integrity sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==
+
+discord-api-types@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.27.2.tgz#a9d3cbce6af41786e0b1abee02c90702be60b08b"
+  integrity sha512-70Uy283dXKpphwuVQIhQJCBAMIxLwCywdyjTKAjjrzFONZZIRQr9oupj3K1rS+hGnI6cp6y7eStRQvTbeSC+Zw==
 
 discord.js@^13.1.0:
   version "13.6.0"
@@ -3252,7 +3291,7 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@~2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.5, node-fetch@^2.6.7, node-fetch@~2.6.1:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,10 +1642,10 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
## Overview

This pull request adds slash commands support to `pleasantcord`. Slash commands are registered when a new release is released.

All users have to reinvite the bot as it requires a new OAuth permission.