### PR TITLE
fix: migrate content props to plural

### DIFF
--- a/src/bot/commands/config.ts
+++ b/src/bot/commands/config.ts
@@ -28,26 +28,25 @@ export default {
       title: 'Server Configuration',
       fields: [
         {
-          name: 'Threshold',
+          name: 'Minimum Threshold',
           value: `${(config?.accuracy * 100).toFixed(2)}%`,
-          inline: true,
         },
         {
-          name: 'Categories',
+          name: 'NSFW Categories',
           value: config.categories.join('\n'),
           inline: true,
         },
         {
-          name: 'Content Types',
-          value: config.content.join(', '),
+          name: 'Scanned Contents',
+          value: config.contents.join('\n'),
           inline: true,
         },
         {
           name: 'Action',
-          value: config.delete ? 'Delete' : 'Blur',
+          value: config.delete ? 'Delete' : 'Repost with blur',
         },
         {
-          name: 'Model',
+          name: 'Classifier Name',
           value: config.model,
         },
         {

--- a/src/bot/service/classifier.ts
+++ b/src/bot/service/classifier.ts
@@ -51,7 +51,7 @@ export async function moderateContent(
 
   const contents: Content[] = getFilterableContents(
     msg,
-    config.content.includes('Sticker')
+    config.contents.includes('Sticker')
   );
   if (contents.length === 0) {
     return;

--- a/src/entity/config.test.ts
+++ b/src/entity/config.test.ts
@@ -23,7 +23,7 @@ describe('getContentTypeFromConfig', () => {
   it('should return an empty array', () => {
     const config = {
       ...BASE_CONFIG,
-      content: [],
+      contents: [],
     };
 
     const mimes = getContentTypeFromConfig(config);
@@ -34,7 +34,7 @@ describe('getContentTypeFromConfig', () => {
   it('should return images only', () => {
     const config: Configuration = {
       ...BASE_CONFIG,
-      content: ['Image'],
+      contents: ['Image'],
     };
 
     const mimes = getContentTypeFromConfig(config);

--- a/src/entity/config.ts
+++ b/src/entity/config.ts
@@ -16,7 +16,7 @@ export interface Configuration {
   // Model name to be used to classifify contents
   readonly model: ModelType;
   // Content type to be moderated
-  readonly content: ContentType[];
+  readonly contents: ContentType[];
 }
 
 // Default configuration for all servers.
@@ -25,7 +25,7 @@ export const BASE_CONFIG: Configuration = {
   categories: ['Hentai', 'Porn'],
   delete: true,
   model: 'MobileNet',
-  content: ['Image', 'Video'],
+  contents: ['Image', 'Video'],
 };
 
 /**
@@ -37,7 +37,7 @@ export const BASE_CONFIG: Configuration = {
 export function getContentTypeFromConfig(config: Configuration): string[] {
   const mime: string[] = [];
 
-  config.content.forEach(type => {
+  config.contents.forEach(type => {
     mime.push(...CONTENT_TYPE_MAP[type]);
   });
 


### PR DESCRIPTION
## Overview

This pull request migrates configuration entity props from `content` to `contents` due to a change from the API.