### PR TITLE
fix(ci): remove un from install command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           version: 7.1.1
       - name: Install dependencies
-        run: pnpm run install
+        run: pnpm install
       - name: Lint code
         run: pnpm run lint:fix
       - name: Test code


### PR DESCRIPTION
## Overview

This pull request removes `run` from `pnpm run install` command.