### PR TITLE
fix: show error message when classify content command is executed under non-identifiable contents

### DIFF
--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -1,6 +1,6 @@
 import { Guild, MessageEmbed, TextChannel } from 'discord.js';
 
-import { Credentials, registerSlashCommands } from '../service/command';
+import { Credentials, registerCommands } from '../service/command';
 
 import { BASE_CONFIG } from './../../entity/config';
 
@@ -22,7 +22,7 @@ export default {
         token: client.token as string,
       };
 
-      return registerSlashCommands(guild.id, creds);
+      return registerCommands(guild.id, creds);
     } catch (err) {
       const embed = handleError(err as Error) as MessageEmbed;
 

--- a/src/bot/events/interactionCreate.ts
+++ b/src/bot/events/interactionCreate.ts
@@ -1,6 +1,6 @@
 import { Interaction, Message, MessageEmbed, TextChannel } from 'discord.js';
 
-import { UNKNOWN_COMMAND_EMBED } from './../../constants/embeds';
+import { EMPTY_EMBED, UNKNOWN_COMMAND_EMBED } from './../../constants/embeds';
 import { BotContext, CommandHandlerParams } from '../types';
 
 import { getCommands, handleError } from '../utils';
@@ -38,7 +38,14 @@ export default {
           timestamp: interaction.createdTimestamp,
           message,
         };
-        embeds = await handler(ctx, params);
+
+        const handlerEmbeds = await handler(ctx, params);
+
+        if (handlerEmbeds.length) {
+          embeds = handlerEmbeds;
+        } else {
+          embeds = [EMPTY_EMBED];
+        }
       }
 
       return interaction.reply({ embeds });

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -7,7 +7,7 @@ import { handleError, getCommandFromMessage, getCommands } from '../utils';
 import { BotContext, CommandHandlerParams } from '../types';
 
 import { PREFIX } from '../../constants/command';
-import { UNKNOWN_COMMAND_EMBED } from '../../constants/embeds';
+import { EMPTY_EMBED } from '../../constants/embeds';
 
 export default {
   event: 'messageCreate',
@@ -24,7 +24,7 @@ export default {
         const commandMap = getCommands();
         const handler = commandMap[getCommandFromMessage(msg.content)].fn;
 
-        let embeds: MessageEmbed[] = [UNKNOWN_COMMAND_EMBED];
+        let embeds: MessageEmbed[] = [EMPTY_EMBED];
 
         if (handler) {
           const params: CommandHandlerParams = {

--- a/src/bot/service/command.ts
+++ b/src/bot/service/command.ts
@@ -18,7 +18,7 @@ export interface Credentials {
  * @param {string} creds.clientID Discord's client ID
  * @param {string} creds.token Discord's bot token
  */
-export async function registerSlashCommands(
+export async function registerCommands(
   guildID: string,
   { clientID, token }: Credentials
 ): Promise<void> {
@@ -43,6 +43,6 @@ export async function registerSlashCommands(
     });
   } catch (err) {
     const { message } = err as Error;
-    throw new Error(`Failed to register slash commands: ${message}`);
+    throw new Error(`Failed to register commands: ${message}`);
   }
 }

--- a/src/constants/embeds.ts
+++ b/src/constants/embeds.ts
@@ -14,3 +14,15 @@ export const UNKNOWN_COMMAND_EMBED = new MessageEmbed({
     // eslint-disable-next-line max-len
     `**pleasantcord** doesn't recognize the command that have been just sent.\nPlease refer to **${PREFIX}help** to show all available **pleasantcords's** commands.`,
 });
+
+export const EMPTY_EMBED = new MessageEmbed({
+  author: {
+    name: 'pleasantcord',
+    iconURL: process.env.IMAGE_URL,
+  },
+  color: RED,
+  title: 'Empty Content',
+  description:
+    // eslint-disable-next-line max-len
+    `**pleasantcord** doesn't detect any identifiable content in this message.`,
+});


### PR DESCRIPTION
## Overview

This pull request fixes a bug when `Classify Content` command is used on non-identifiable message. Now, it will reply with empty message instead.