### PR TITLE
fix: remove fn shorthand for nil check

### DIFF
--- a/src/bot/events/interactionCreate.ts
+++ b/src/bot/events/interactionCreate.ts
@@ -30,7 +30,7 @@ export default {
 
     try {
       const commandMap = await getCommands();
-      const handler = commandMap[interaction.commandName].fn;
+      const handler = commandMap[interaction.commandName];
 
       let embeds: EmbedBuilder[] = [UNKNOWN_COMMAND_EMBED];
 
@@ -42,7 +42,7 @@ export default {
           message,
         };
 
-        const handlerEmbeds = await handler(ctx, params);
+        const handlerEmbeds = await handler.fn(ctx, params);
 
         if (handlerEmbeds.length) {
           embeds = handlerEmbeds;

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -26,7 +26,7 @@ export default {
 
       if (msg.content.startsWith(PREFIX)) {
         const commandMap = await getCommands();
-        const handler = commandMap[getCommandFromMessage(msg.content)].fn;
+        const handler = commandMap[getCommandFromMessage(msg.content)];
 
         let embeds: EmbedBuilder[] = [EMPTY_EMBED];
 
@@ -36,7 +36,7 @@ export default {
             channel: msg.channel as TextChannel,
             timestamp: msg.createdTimestamp,
           };
-          embeds = await handler(ctx, params);
+          embeds = await handler.fn(ctx, params);
         }
 
         return msg.channel.send({ embeds });


### PR DESCRIPTION
## Overview

This pull request fixes command shorthand that may lead to `undefined` if the command is not found.